### PR TITLE
Add puppeteer to skip downloading later

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -5,3 +5,8 @@ RUN apt-get update && apt-get install -y \
 	libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
 	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0 \
 	postgresql-client-11
+
+RUN npm install --unsafe-perm --global puppeteer@3.0.2
+
+# So we can skip chromium downloads later
+RUN /bin/bash -l -c 'echo export PUPPETEER_EXECUTABLE_PATH="$(find $(npm root -g) -type f -executable -name chrome)" >> ~/.bashrc'

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -30,7 +30,10 @@ RUN apt-get update && apt-get install -y gnuplot \
 # in non-privileged containers
 RUN sed -i 's/[ \t]*ulimit.*/:/g' /etc/init.d/redis-server
 
-RUN npm install --unsafe-perm --global balena-cli
+RUN npm install --unsafe-perm --global balena-cli puppeteer@3.0.2
+
+# So we can skip chromium downloads later
+RUN /bin/bash -l -c 'echo export PUPPETEER_EXECUTABLE_PATH="$(find $(npm root -g) -type f -executable -name chrome)" >> ~/.bashrc'
 
 # So we can use rabbitmqadmin
 RUN rabbitmq-plugins enable rabbitmq_management


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add `puppeteer` to base images and set environment variable to install location so we can skip downloading Chromium every time we run tests.