### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @lucianbuzzo @jviotti @karaxuna @StefKors @joshbwlng @grahammcculloch @Ljewalsh


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Part of the move to stop using `CODEOWNERS` on all `productOS` repos.