### PR TITLE
Update puppeteer to 3.3.0

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
 	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0 \
 	postgresql-client-11 libxcb-dri3-0 libdrm2 libgbm1
 
-RUN npm install --unsafe-perm --global puppeteer@3.0.2
+RUN npm install --unsafe-perm --global puppeteer@3.3.0
 
 # So we can skip chromium downloads later
 RUN /bin/bash -l -c 'echo export PUPPETEER_EXECUTABLE_PATH="$(find $(npm root -g) -type f -executable -name chrome)" >> ~/.bashrc'

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y gnuplot \
 # in non-privileged containers
 RUN sed -i 's/[ \t]*ulimit.*/:/g' /etc/init.d/redis-server
 
-RUN npm install --unsafe-perm --global balena-cli puppeteer@3.0.2
+RUN npm install --unsafe-perm --global balena-cli puppeteer@3.3.0
 
 # So we can skip chromium downloads later
 RUN /bin/bash -l -c 'echo export PUPPETEER_EXECUTABLE_PATH="$(find $(npm root -g) -type f -executable -name chrome)" >> ~/.bashrc'


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

- Update `puppeteer` to latest version `3.3.0`
- Update baked in Chromium from `linux-737027` to `linux-756035`