### PR TITLE
Update base image tag, set chrome env var

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -1,4 +1,6 @@
-FROM balena/open-balena-base:v9.2.1
+FROM balena/open-balena-base:v9.4.1
+
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/local/bin/chrome
 
 RUN apt-get update && apt-get install -y \
 	libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 \
@@ -9,4 +11,4 @@ RUN apt-get update && apt-get install -y \
 RUN npm install --unsafe-perm --global puppeteer@4.0.1
 
 # So we can skip chromium downloads later
-RUN /bin/bash -l -c 'echo export PUPPETEER_EXECUTABLE_PATH="$(find $(npm root -g) -type f -executable -name chrome)" >> ~/.bashrc'
+RUN /bin/bash -l -c 'ln -s $(find $(npm root -g) -type f -executable -name chrome) /usr/local/bin/chrome'

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,6 @@
-FROM balena/open-balena-base:v9.2.1
+FROM balena/open-balena-base:v9.4.1
+
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/local/bin/chrome
 
 # For debugging purposes
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
@@ -33,7 +35,7 @@ RUN sed -i 's/[ \t]*ulimit.*/:/g' /etc/init.d/redis-server
 RUN npm install --unsafe-perm --global balena-cli puppeteer@4.0.1
 
 # So we can skip chromium downloads later
-RUN /bin/bash -l -c 'echo export PUPPETEER_EXECUTABLE_PATH="$(find $(npm root -g) -type f -executable -name chrome)" >> ~/.bashrc'
+RUN /bin/bash -l -c 'ln -s $(find $(npm root -g) -type f -executable -name chrome) /usr/local/bin/chrome'
 
 # So we can use rabbitmqadmin
 RUN rabbitmq-plugins enable rabbitmq_management


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

This PR:
- updates base image to latest version
- sets `PUPPETEER_EXECUTABLE_PATH` to point to a symlink that leads to the actual chrome executable
  - much preferable to the current method of exporting `PUPPETEER_EXECUTABLE_PATH` in `/root/.bashrc`