### PR TITLE
Upgrade Postgres packages from 11 to 12

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -5,7 +5,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/local/bin/chrome
 # For debugging purposes
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN apt-get update && apt-get install -y postgresql-client-11 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y postgresql-client-12 && rm -rf /var/lib/apt/lists/*
 
 RUN git clone git://github.com/hoxu/gitstats.git && cd gitstats && make install
 
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y gnuplot \
 	python-pip libx11-xcb1 libxcomposite1 \
 	libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
 	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0 \
-	shellcheck redis-server postgresql-11 \
+	shellcheck redis-server postgresql-12 \
 	rabbitmq-server
 
 # Redis will try to set ulimit at startup, and that won't work


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Upgrade installed Postgres packages from 11 to 12