### PR TITLE
Add Renovate to bump base docker images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,28 @@
+{
+  "extends": [
+    "config:base",
+    "docker:enableMajor"
+  ],
+  "ignorePaths": [],
+  "enabledManagers": [
+    "docker"
+  ],
+  "pruneStaleBranches": false,
+  "rangeStrategy": "bump",
+  "commitMessagePrefix": "patch:",
+  "commitBody": "Change-type: patch",
+  "prHourlyLimit": 0,
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "groupName": "non-major",
+      "updateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Trying out a Renovate config to automatically bump Dockerfile base image versions.