### PR TITLE
Replace puppeteer with playwright

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -9,14 +9,12 @@ RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/loc
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
-# Install chrome dependencies and postgresql-client
+# Install chromium dependencies and postgresql-client
 RUN apt-get update && apt-get install -y libx11-xcb1 libxcomposite1 \
 	libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
 	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0 libxshmfence1 \
 	libxcb-dri3-0 libdrm-dev libgbm-dev postgresql-client-12 && rm -rf /var/lib/apt/lists/*
 
 # So we can skip chromium downloads later
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/local/bin/chrome
 COPY package*.json /usr/src/jellyfish-test/
-RUN npm install && \
-      /bin/bash -l -c 'ln -s $(find /usr/src/jellyfish-test/node_modules -type f -executable -name chrome) $PUPPETEER_EXECUTABLE_PATH'
+RUN npm install && npx playwright install chromium

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "url": "https://github.com/product-os/jellyfish-base-images/issues"
   },
   "homepage": "https://github.com/product-os/jellyfish-base-images#readme",
-  "dependencies": {
-    "puppeteer": "^13.3.2"
-  },
   "versionist": {
     "publishedAt": "2022-02-15T20:29:17.414Z"
+  },
+  "dependencies": {
+    "playwright": "^1.19.0"
   }
 }


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

As part of the work to switch from `puppeteer` to `playwright`: https://github.com/product-os/jellyfish/pull/7910