### PR TITLE
Install `postgresql-client-13` instead of version 12

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -5,7 +5,7 @@ WORKDIR /usr/src/jellyfish-test
 # Download go-task (taskfile)
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
-# Add repository for postgresql-client-12
+# Add repository for postgresql-client-13
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
@@ -13,7 +13,7 @@ RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-k
 RUN apt-get update && apt-get install -y libx11-xcb1 libxcomposite1 \
 	libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
 	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0 libxshmfence1 \
-	libxcb-dri3-0 libdrm-dev libgbm-dev postgresql-client-12 && rm -rf /var/lib/apt/lists/*
+	libxcb-dri3-0 libdrm-dev libgbm-dev postgresql-client-13 && rm -rf /var/lib/apt/lists/*
 
 # So we can skip chromium downloads later
 COPY package*.json /usr/src/jellyfish-test/

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,14 +6,21 @@ WORKDIR /usr/src/jellyfish-test
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
 # Add repository for postgresql-client-13
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update && \
+	apt-get install -y lsb-release && \
+	echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list; \
+	apt-get purge lsb-release
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 # Install chromium dependencies and postgresql-client
-RUN apt-get update && apt-get install -y libx11-xcb1 libxcomposite1 \
-	libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
-	gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0 libxshmfence1 \
-	libxcb-dri3-0 libdrm-dev libgbm-dev postgresql-client-13 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+	apt-get install -y libx11-xcb1 libxcomposite1 libxcursor1 \
+		libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
+		gconf-gsettings-backend libasound2 libatk1.0-0 libgtk-3-0 \
+		libxshmfence1 libxcb-dri3-0 libdrm-dev libgbm-dev \
+		postgresql-client-13 && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
 
 # So we can skip chromium downloads later
 COPY package*.json /usr/src/jellyfish-test/


### PR DESCRIPTION
Change-type: major
Signed-off-by: Carol Schulze <carol@ereski.org>